### PR TITLE
Check the needed env vars are provided to the backfill script

### DIFF
--- a/backfill.py
+++ b/backfill.py
@@ -6,6 +6,12 @@ from os import environ
 import boto3
 
 
+if not all([environ.get('AWS_S3_BUCKET'), environ.get('AWS_SQS_URL')]):
+    print('You have to specify the AWS_S3_BUCKET and AWS_SQS_URL environment variables.')
+    print('Check the "Backfilling data" section of the README file for more info.')
+    exit(1)
+
+
 bucket = boto3.resource('s3').Bucket(environ.get('AWS_S3_BUCKET'))
 queue = boto3.resource('sqs').Queue(environ.get('AWS_SQS_URL'))
 


### PR DESCRIPTION
This should avoid ugly stack traces like the one mentioned in https://github.com/AppliedTrust/traildash/issues/2#issuecomment-101875798.
