### PR TITLE
Support S3 Create events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-FROM ubuntu:14.04
-MAINTAINER AppliedTrust
+#TO_BUILD: docker build -t docker.internal.community.nw.ops.here.com/traildash:latest .
 
-RUN apt-get update && apt-get -y install openjdk-7-jre-headless wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN wget -q -O /usr/src/elasticsearch.deb https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.deb && dpkg -i /usr/src/elasticsearch.deb
+FROM    ubuntu:14.04
+MAINTAINER Holger Morch <holger.morch@here.com>
 
-#
-RUN echo "# CORS settings:\nhttp.cors.enabled: true\nhttp.cors.allow-origin: true\n" >> /etc/elasticsearch/elasticsearch.yml
-ADD dist/linux/amd64/traildash /usr/local/traildash/traildash 
+RUN     apt-get update && apt-get -y install openjdk-7-jre-headless wget python python-pip && pip install boto3 && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN     wget -q -O /usr/src/elasticsearch.deb https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.deb && dpkg -i /usr/src/elasticsearch.deb
 
 #
-ADD assets/start /root/start
-RUN chmod 755 /root/start /usr/local/traildash/traildash
+RUN     echo "# CORS settings:\nhttp.cors.enabled: true\nhttp.cors.allow-origin: true\n" >> /etc/elasticsearch/elasticsearch.yml
+ADD     traildash /usr/local/traildash/traildash
+
+# 
+ADD     backfill.py /usr/local/bin/
+
+#
+ADD     start /root/start
+RUN     chmod 755 /root/start /usr/local/traildash/traildash /usr/local/bin/backfill.py
 
 EXPOSE 7000
 CMD ["/root/start"]
 
-
+ADD     Dockerfile /

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN     wget -q -O /usr/src/elasticsearch.deb https://download.elasticsearch.org
 
 #
 RUN     echo "# CORS settings:\nhttp.cors.enabled: true\nhttp.cors.allow-origin: true\n" >> /etc/elasticsearch/elasticsearch.yml
-ADD     traildash /usr/local/traildash/traildash
+ADD     dist/linux/amd64/traildash /usr/local/traildash/traildash
 
 # 
 ADD     backfill.py /usr/local/bin/

--- a/traildash.go
+++ b/traildash.go
@@ -38,7 +38,9 @@ AWS credentials are sourced by (in order): Environment Variables, ~/.aws/credent
 	AWS_SECRET_ACCESS_KEY	AWS Secret Key.
 
 Optional Environment Variables:
-	AWS_REGION		AWS Region (SQS and S3 regions must match. default: us-east-1).
+	AWS_REGION		AWS Region (SQS and S3 region. default: us-east-1).
+	AWS_REGION_S3   AWS Region for S3 (overrides AWS_REGION for S3 if present. default: value of AWS_REGION)
+    AWS_REGION_SQS  AWS Region for SQS (overrides AWS_REGION for SQS if present. default: value of AWS_REGION)
 	ES_URL			ElasticSearch URL (default: http://localhost:9200).
 	WEB_LISTEN		Listen IP and port for HTTP/HTTPS interface (default: 0.0.0.0:7000).
 	SSL_MODE		"off": disable HTTPS and use HTTP (default)
@@ -379,8 +381,9 @@ func (c *config) download(m *cloudtrailNotification) (*[]cloudtrailRecord, error
 		return nil, fmt.Errorf("Expected one S3 key but got %d", len(m.S3ObjectKey[0]))
 	}
 	q := s3.GetObjectInput{
-		Bucket: aws.String(m.S3Bucket),
-		Key:    aws.String(m.S3ObjectKey[0]),
+		Bucket:                   aws.String(m.S3Bucket),
+		Key:                      aws.String(m.S3ObjectKey[0]),
+		ResponseContentEncoding:  aws.String("gzip"),
 	}
 	o, err := c.s.GetObject(&q)
 	if err != nil {


### PR DESCRIPTION
We have a case where we can't use the SNS messages created by CloudTrail. But we can use events created by S3 when an object is created. This messages look different then the one from CloudTrail but contain all necessary data. So I convert this message to a CloudTrail one and go on.

AWS S3 Event reference: https://docs.aws.amazon.com/AmazonS3/latest/UG/SettingBucketNotifications.html

Example S3 message:
{
  "Records": [
    {
      "eventVersion": "2.0",
      "eventSource": "aws:s3",
      "awsRegion": "eu-west-1",
      "eventTime": "2015-08-27T08:48:40.124Z",
      "eventName": "ObjectCreated:Copy",
      "userIdentity": {
        "principalId": "<strip>"
      },
      "requestParameters": {
        "sourceIPAddress": "127.0.0.1"
      },
      "responseElements": {
        "x-amz-request-id": "<strip>",
        "x-amz-id-2": "<strip>"
      },
      "s3": {
        "s3SchemaVersion": "1.0",
        "configurationId": "CloudTrailAdded",
        "bucket": {
          "name": "MyCloudTrailLogs",
          "ownerIdentity": {
            "principalId": "<strip>"
          },
          "arn": "arn:aws:s3:::MyCloudTrailLogs"
        },
        "object": {
          "key": "AWSLogs/<accountId>/CloudTrail/eu-west-1/2015/08/26/<accountId_CloudTrail_eu-west-1_20150826T0015Z_3HX7CI5fnU0uEUp6.json.gz",
          "size": 14358,
          "sequencer": "0055DECEE7B29D2D6A"
        }
      }
    }
  ]
}
